### PR TITLE
Run tailored data extraction on new form

### DIFF
--- a/lib/entities/semantic-file.js
+++ b/lib/entities/semantic-file.js
@@ -123,8 +123,8 @@ export class SemanticFile {
       filename: sparqlEscape(this.filename, 'string'),
       ext: sparqlEscape(this.extension, 'string'),
       format: sparqlEscape(this.format, 'string'),
-      created: sparqlEscape(this.created.toISOString(), 'date'),
-      modified: sparqlEscape(this.modified.toISOString(), 'date'),
+      created: sparqlEscape(this.created.toISOString(), 'datetime'),
+      modified: sparqlEscape(this.modified.toISOString(), 'datetime'),
       publisher: `<${this.publisher}>`,
     };
 

--- a/lib/entities/semantic-form.js
+++ b/lib/entities/semantic-form.js
@@ -5,6 +5,7 @@ import { SEMANTIC_FORM_TYPE } from '../../env';
 export const SEMANTIC_FORM_STATUS = {
   SENT: 'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c',
   CONCEPT: 'http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd',
+  NEW: 'http://lblod.data.gift/concepts/6b7ae118-4653-48f2-9d9a-4712f8c30da9',
 };
 
 /**

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -83,15 +83,16 @@ export class SemanticFormManagement {
    */
   async getSemanticFormBundle(uuid) {
     const form = await this.getSemanticForm(uuid);
+    let configuration = null;
 
     /**
-     * NOTE: a form is NEW until it's saved by the user, then becoming CONCEPT
+     * NOTE: in the case where one source is set, we assume it to be the form.ttl (new semantic-form)
      */
-    if (form.status === SEMANTIC_FORM_STATUS.NEW) {
+    if (form.sources.length === 1) {
+      // TODO: make this a little more type safe / solid
       let sources = {};
       try {
-        const ttlForm = new SemanticFile(form.sources.filter(source => source.physicalURI.endsWith('form.ttl'))[0]);
-        sources = await this.configuration.sources.getLatest(ttlForm.uri);
+        sources = await this.configuration.sources.getLatest(form.sources[0].uri);
       } catch (error) {
         throw {
           status: 404,
@@ -100,13 +101,6 @@ export class SemanticFormManagement {
           },
           message: `Could not retrieve/find form configuration for the semantic-form ${uuid}`
         };
-      }
-
-      // If other sources are found, such as old metadata we want to override them.
-      const otherSources = form.sources.filter(source => !source.physicalURI.endsWith('form.ttl'));
-      if (otherSources.length) {
-        const triples = formSourcesToNT(form, otherSources);
-        await this.mutator.delete(triples, form.graph);
       }
 
       let {configuration, meta} = sources;
@@ -145,7 +139,36 @@ export class SemanticFormManagement {
         }
       }
 
-      if (configuration.tailored.source) {
+      // SAVE
+      try {
+        await this.updateSemanticForm(uuid, form);
+      } catch (e) {
+        console.warn(`Failed updating sources for semantic-form with ${uuid}`);
+        console.log(e);
+      }
+    }
+
+    if (form.status === SEMANTIC_FORM_STATUS.NEW) {
+      if (!configuration) {
+        // No configuration means multiple sources found. Can be for example :
+        // form.ttl, form.json, tailored extracted data ...
+        // --> We assume only one form.ttl and use it.
+        const ttlSource = form.sources.filter(source => source.physicalURI.endsWith('form.ttl'))[0];
+        configuration = (await this.configuration.sources.getLatest(ttlSource.uri)).configuration;
+      }
+      if (configuration && configuration.tailored.source) {
+        // Clean previously extracted data
+        const removes = await new SourceDataExtractor().extract(form.uri, configuration.specification.definition, false);
+        if (removes) {
+          try {
+            await this.mutator.delete(removes, form.graph);
+          } catch (e) {
+            console.warn(`Failed removing extracted source data ${uuid}`);
+            console.log(e);
+          }
+        }
+
+        // Extract new data
         const extractors = configuration.tailored.source.content;
         const {additions} = await new TailoredMetaDataExtractor(form).execute(extractors);
         if (additions) {
@@ -156,14 +179,14 @@ export class SemanticFormManagement {
             console.log(e);
           }
         }
-      }
 
-      // SAVE
-      try {
-        await this.updateSemanticForm(uuid, form);
-      } catch (e) {
-        console.warn(`Failed updating sources for semantic-form with ${uuid}`);
-        console.log(e);
+        // SAVE
+        try {
+          await this.updateSemanticForm(uuid, form);
+        } catch (e) {
+          console.warn(`Failed updating sources for semantic-form with ${uuid}`);
+          console.log(e);
+        }
       }
     }
 
@@ -373,23 +396,4 @@ WHERE {
     };
   }
   return response.results.bindings.map(binding => binding.source.value);
-}
-
-function formSourcesToNT(form, sources) {
-  let buffer = [];
-
-  const prefixes = [
-    '@prefix mu: <http://mu.semte.ch/vocabularies/core/> .',
-    '@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .',
-    '@prefix adms: <http://www.w3.org/ns/adms#>  .',
-    '@prefix dct: <http://purl.org/dc/terms/> .',
-  ];
-
-  buffer.push(prefixes.join('\n'));
-
-  sources.forEach(source => {
-    buffer.push(`<${form.uri}> dct:source <${source.uri}> .`);
-  });
-
-  return buffer.join('\n').trim();
 }

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -158,7 +158,7 @@ export class SemanticFormManagement {
       }
       if (configuration && configuration.tailored.source) {
         // Clean previously extracted data
-        const removes = await new SourceDataExtractor().extract(form.uri, configuration.specification.definition, false);
+        const removes = await new SourceDataExtractor().extract(form.uri, configuration.specification.definition);
         if (removes) {
           try {
             await this.mutator.delete(removes, form.graph);

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -85,13 +85,13 @@ export class SemanticFormManagement {
     const form = await this.getSemanticForm(uuid);
 
     /**
-     * NOTE: in the case where one source is set, we assume it to be the form.ttl (new semantic-form)
+     * NOTE: a form is NEW until it's saved by the user, then becoming CONCEPT
      */
-    if (form.sources.length === 1) {
-      // TODO: make this a little more type safe / solid
+    if (form.status === SEMANTIC_FORM_STATUS.NEW) {
       let sources = {};
       try {
-        sources = await this.configuration.sources.getLatest(form.sources[0].uri);
+        const ttlForm = new SemanticFile(form.sources.filter(source => source.physicalURI.endsWith('form.ttl'))[0]);
+        sources = await this.configuration.sources.getLatest(ttlForm.uri);
       } catch (error) {
         throw {
           status: 404,
@@ -101,6 +101,14 @@ export class SemanticFormManagement {
           message: `Could not retrieve/find form configuration for the semantic-form ${uuid}`
         };
       }
+
+      // If other sources are found, such as old metadata we want to override them.
+      const otherSources = form.sources.filter(source => !source.physicalURI.endsWith('form.ttl'));
+      if (otherSources.length) {
+        const triples = formSourcesToNT(form, otherSources);
+        await this.mutator.delete(triples, form.graph);
+      }
+
       let {configuration, meta} = sources;
 
       form.sources = [
@@ -137,9 +145,6 @@ export class SemanticFormManagement {
         }
       }
 
-      /**
-       * NOTE: generate and save tailored TTL if is has been configured.
-       */
       if (configuration.tailored.source) {
         const extractors = configuration.tailored.source.content;
         const {additions} = await new TailoredMetaDataExtractor(form).execute(extractors);
@@ -163,6 +168,7 @@ export class SemanticFormManagement {
     }
 
     const bundle = new SemanticFormBundle(form.sources);
+
     /**
      * NOTE: we expect that at this point sources (spec., meta, ...) have been set on the semantic-form
      */
@@ -367,4 +373,23 @@ WHERE {
     };
   }
   return response.results.bindings.map(binding => binding.source.value);
+}
+
+function formSourcesToNT(form, sources) {
+  let buffer = [];
+
+  const prefixes = [
+    '@prefix mu: <http://mu.semte.ch/vocabularies/core/> .',
+    '@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .',
+    '@prefix adms: <http://www.w3.org/ns/adms#>  .',
+    '@prefix dct: <http://purl.org/dc/terms/> .',
+  ];
+
+  buffer.push(prefixes.join('\n'));
+
+  sources.forEach(source => {
+    buffer.push(`<${form.uri}> dct:source <${source.uri}> .`);
+  });
+
+  return buffer.join('\n').trim();
 }

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -148,7 +148,7 @@ export class SemanticFormManagement {
     }
 
     if (form.status === SEMANTIC_FORM_STATUS.NEW) {
-      const ttlSource = form.sources.filter(source => source.physicalURI.endsWith('form.ttl'))[0];
+      const ttlSource = mostRecentSource(form.sources.filter(source => source.physicalURI.endsWith('form.ttl')));
       const configuration = (await this.configuration.sources.getLatest(ttlSource.uri)).configuration;
 
       if (configuration && configuration.tailored.source) {
@@ -391,4 +391,19 @@ WHERE {
     };
   }
   return response.results.bindings.map(binding => binding.source.value);
+}
+
+function mostRecentSource(sources) {
+  return sources.reduce(function (previousMostRecent, currentMostRecent) {
+    const previousTimestamp = previousMostRecent ? getTimestamp(previousMostRecent.physicalURI) : 0;
+    const currentTimestamp = getTimestamp(currentMostRecent.physicalURI);
+    return (previousTimestamp > currentTimestamp) ? previousMostRecent : currentMostRecent;
+  });
+}
+
+function getTimestamp(fileAddress) {
+  const splittedPhysicalUri = fileAddress.split('/');
+  const timestampedFolder = splittedPhysicalUri[splittedPhysicalUri.length - 2];
+  const timestamp = timestampedFolder.split('-')[0];
+  return timestamp;
 }

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -83,7 +83,6 @@ export class SemanticFormManagement {
    */
   async getSemanticFormBundle(uuid) {
     const form = await this.getSemanticForm(uuid);
-    let configuration = null;
 
     /**
      * NOTE: in the case where one source is set, we assume it to be the form.ttl (new semantic-form)
@@ -149,13 +148,9 @@ export class SemanticFormManagement {
     }
 
     if (form.status === SEMANTIC_FORM_STATUS.NEW) {
-      if (!configuration) {
-        // No configuration means multiple sources found. Can be for example :
-        // form.ttl, form.json, tailored extracted data ...
-        // --> We assume only one form.ttl and use it.
-        const ttlSource = form.sources.filter(source => source.physicalURI.endsWith('form.ttl'))[0];
-        configuration = (await this.configuration.sources.getLatest(ttlSource.uri)).configuration;
-      }
+      const ttlSource = form.sources.filter(source => source.physicalURI.endsWith('form.ttl'))[0];
+      const configuration = (await this.configuration.sources.getLatest(ttlSource.uri)).configuration;
+
       if (configuration && configuration.tailored.source) {
         // Clean previously extracted data
         const removes = await new SourceDataExtractor().extract(form.uri, configuration.specification.definition);

--- a/lib/services/source-data-extractor.js
+++ b/lib/services/source-data-extractor.js
@@ -17,9 +17,9 @@ export class SourceDataExtractor {
    *
    * @returns {Promise<{string}>} - The n-triples that have been extracted.
    */
-  async extract(uri, definition, nested=true) {
+  async extract(uri, definition) {
     try {
-      const response = await query(generateQuery(uri, definition, nested));
+      const response = await query(generateQuery(uri, definition));
       const rows = bindingsToNT(response.results.bindings);
       if (rows) {
         /**
@@ -50,7 +50,7 @@ export class SourceDataExtractor {
  *
  * @returns {string}
  */
-function generateQuery(uri, {prefixes, resources, properties}, nested=true) {
+function generateQuery(uri, {prefixes, resources, properties}) {
   return `${prefixes.join('\n')}
 SELECT * WHERE
 {
@@ -66,7 +66,7 @@ SELECT * WHERE
             ?s ?p ?o .
         }
     }
-    ${nested ? resources.map(resource => generateNestedResourceSubQuery(uri, resource)).join('') : ''}
+    ${resources.map(resource => generateNestedResourceSubQuery(uri, resource)).join('')}
 }`;
 }
 

--- a/lib/services/source-data-extractor.js
+++ b/lib/services/source-data-extractor.js
@@ -17,9 +17,9 @@ export class SourceDataExtractor {
    *
    * @returns {Promise<{string}>} - The n-triples that have been extracted.
    */
-  async extract(uri, definition) {
+  async extract(uri, definition, nested=true) {
     try {
-      const response = await query(generateQuery(uri, definition));
+      const response = await query(generateQuery(uri, definition, nested));
       const rows = bindingsToNT(response.results.bindings);
       if (rows) {
         /**
@@ -50,7 +50,7 @@ export class SourceDataExtractor {
  *
  * @returns {string}
  */
-function generateQuery(uri, {prefixes, resources, properties}) {
+function generateQuery(uri, {prefixes, resources, properties}, nested=true) {
   return `${prefixes.join('\n')}
 SELECT * WHERE
 {
@@ -66,7 +66,7 @@ SELECT * WHERE
             ?s ?p ?o .
         }
     }
-    ${resources.map(resource => generateNestedResourceSubQuery(uri, resource)).join('')}
+    ${nested ? resources.map(resource => generateNestedResourceSubQuery(uri, resource)).join('') : ''}
 }`;
 }
 


### PR DESCRIPTION
We use to use a trick to determine if a form is new or not to run the
extraction. It has a limitation: if we create a form before the data
needed for the extraction are saved at the proper place, then we
couldn't get those data back.

Now, there is a "NEW" status on the forms which gets updated only when
the form gets saved. Everytime we load a "NEW" form, we clean previously
extracted data and then we extract the most recent tailored data.