### PR TITLE
Refactoring/improve-semantic-form-enrichment-logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,119 +1,149 @@
 # subsidy-applications-management-service
 
-Service that provides management related to subsidy-applications (subsidie-aanvragen) semantic-forms.
+Service that provides management of one or more SemanticForm(s).
 
 This includes but is not limited to:
-- semantic-form versioning
-- providing all the (meta)data needed to construct/visualize a semantic-form
-- updating and deleting the source-data of a semantic-form
-- submitting a semantic-form
+- providing and managing all the (meta)data needed to construct/visualize a SemanticForm
+- updating and deleting the source-data of a SemanticForm
+    - Note: **NOT** creating
+- submitting a SemanticForm
+- **experimental**: writing tailored meta/source-data extractors
 
 ## Table of contents
 
-- [**Installation**](#installation)
+- [**Setup**](#setup)
+    - [**In a `mu.semte.ch` stack**](#within-a-musemtech-stack)
     - [**Environment variables**](#environment-variables)
-- [**FormData**](#configuration)
-    - [**Form versioning**](#form-versioning)
-        - [**Files: config.json**](#configuration-files-configjson)
-        - [**Files: turtle files**](#configuration-files-turtle-files)
+- [**Configuration**](#configuration)
+    - [**SemanticForm(s)**](#semanticforms)
+        - [**SemanticFormDirectory**](#semanticforms-the-semanticformdirectory)
+        - [**SemanticFormSpecification**](#semanticforms-the-semanticformspecification)
+        - [**[experimental] Tailored data**](#experimental-semanticforms-tailored-data)
+    - [**[deprecated] ~~Mapper~~**](#deprecated-mapper)
+- [**Generates**](#generates)
+    - [**MetaData**](#semanticforms-metadata)
 - [**API**](#api)
-    - [**Get the current active form directory.**](#get-the-current-active-form-directory)
+    - [**Get the configuration and latest meta-data to be used.**](#get-the-configuration-and-latest-meta-data-to-be-used)
     - [**Get all the meta(data) needed to construct a semantic form.**](#get-all-the-metadata-needed-to-construct-a-semantic-form)
     - [**Update the source-data based on a given delta**](#update-the-source-data-based-on-a-given-delta)
     - [**Delete all the source-data for a semantic-form**](#delete-all-the-source-data-for-a-semantic-form)
     - [**Submit a semantic-form**](#submit-a-semantic-form)
+    - [**Sync all meta-data**](#sync-all-meta-data)
 - [**Developing in the `mu.semte.ch` stack**](#development)
 
+## Setup
 
-## Installation
+### Within a [`mu.semte.ch`](https://github.com/mu-semtech) stack
 
-To add the service to your `mu.semte.ch` stack, add the following snippet to docker-compose.yml:
+Paste the following snip-it in your `docker-compose.yml`:
 
 ```yaml
+version: '3.4'
+
 services:
   subsidy-applications-management:
-    image: lblod/subsidy-applications-management-service:x.x.x
+    image: lblod/subsidy-applications-management-service
     volumes:
-      - ./config/semanctic-form-path:/share
+        # change to location of configuration
+      - ./my-config:/config
+        # change to location of file storage
+      - ./my-file-storage:/data
 ```
-> **NOTE**: Make sure to mount the `/share` directory as this location should contain all the configuration for this 
-> service to work correctly.
 
 ### Environment variables
 
-Provided [environment variables](https://docs.docker.com/compose/environment-variables/) by the service. These can be added in within the docker declaration.
+These can be added in within the docker declaration.
 
-| Name                     | Description                                                          | Default                                                        |
-| ------------------------ | -------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `SERVICE_NAME`           | The name of the service                                             | `subsidy-application-management-service`                       |
-| `DATA_QUERY_CHUNK_SIZE`  | Represents the max amount of triples allowed within a query request | `50`                                                           |
-| `FORM_VERSION_DIRECTORY` | Root directory of the form version directories                      | `/share/versions/`                                             |
-| `SEMANTIC_FORM_TYPE`     | Type of the semantic forms to be processed                          | `http://lblod.data.gift/vocabularies/subsidie/ApplicationForm` |
+| Name                               | Description                                                                     | Default                                                                                                                         |
+|------------------------------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `SERVICE_NAME`                     | The name of the service.  Mainly used to identify the service's created files.  | "subsidy-application-management-service"                                                                                        |
+| `SEMANTIC_FORM_TYPE`               | The type that should be used for managed semantic-forms.                        | `lblodSubsidie:ApplicationForm`                                                                |
+| `SEMANTIC_FORM_RESOURCE_BASE`      | Resource URI base to be used when creating new semantic-forms.                  | "http://data.lblod.info/application-forms/"                                                                                     |
+| `SEMANTIC_FORM_CONFIGURATION_ROOT` | Root location of semantic-form configurations within the `config` volume.       | `/config/forms/`                                                                                                                |
+| `QUERY_CHUNK_SIZE`                 | Maximum triple chunk for mutation data queries.                                 | 50                                                                                                                              |
+| `META_DATA_ROOT`                   | Root location of meta-data within the `data` volume                             | `data/meta-files/`                                                                                                              |
+| `META_DATA_CRON`                   | Interval when to retry generating meta-data                                     | `0 */15 8-18 * * 1-5` “At every 15th minute past every hour from 8 through 18 on every day-of-week from Monday through Friday.” |
+| `META_DATA_STALE_CRON_STOP`        | After how many days the `META_DATA_CRON` is considered "stale"               | 5                                                                                                                               |
+| `META_DATA_EXTRACTION_BLACK_LIST`           | concept-scheme values that should be ignored |                 |
 
-## FormData
+> **Developer note**:  
+> For the more tech-savvy, you can also take a peek in `env.js` for a more detailed look.
 
-Some extra configuration files/directories are needed for this service to work correctly. 
-All these extra configuration will be created within the `/share` volume.
+## Configuration
 
-### Form versioning
+### SemanticForm(s)
 
-Within the [`FORM_VERSION_DIRECTORY`](#environment-variables) you can drop **timestamped** directories. 
-These will contain all the files required to: construct, process and visualize semantic-forms that can change over time.
+To start managing forms, you'll first need to configure forms. We'll do this within the [`SEMANTIC_FORM_CONFIGURATION_ROOT`](#environment-variables).
 
-All directories are **REQUIRED** to have a **timestamp** in the [format](https://momentjs.com/docs/#/parsing/string-format/) `YYYYMMDDhhmmss` followed by a dash(-) and a title/description.
+You'll create a new SemanticForm by:
+1) Creating a [SemanticFormDirectory](#semanticforms-the-semanticformdirectory)
+2) Populate the [SemanticFormDirectory](#semanticforms-the-semanticformdirectory), `/versions` directory, with a [SemanticFormSpecification](#semanticforms-the-semanticformspecification)
 
-#### Example directory structure:
+When finished, you'll end up with a structure that could look similar to this:
 
-- 📂 share
-    - 📂 versions
-        - 📂 20201231153419-initial-from
-            - 📝 config.json
-            - 📝 form.ttl
-        - 📁 20201231153459-added-new-sub-form
- 
+- 📂 [`SEMANTIC_FORM_CONFIGURATION_ROOT`](#environment-variables)
+    - 📂 my-form
+        - 📂 versions
+            - 📂 20201231153419-initial-from
+                - 📝 config.json
+                - 📝 form.ttl
+            - 📁 20201231153459-added-new-sub-form
 
-### FormData files: config.json
+### SemanticForm(s): The SemanticFormDirectory
 
-This file contains all static configuration data to be used by the service.
- 
-#### Example:
+The service can manage one or more SemanticForm(s). This is achieved by creating SemanticFormDirectories. These directories contain everything the service will need to build, enhance and manage the SemanticFormBundle for the client.
 
-```json
-{
-  "resource": {
-    "prefixes": [
-      "PREFIX mu: <http://mu.semte.ch/vocabularies/core/>",
-      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
-      "PREFIX dct: <http://purl.org/dc/terms/>",
-      "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>",
-      "PREFIX schema: <http://schema.org/>",
-      "PREFIX foaf: <http://xmlns.com/foaf/0.1/>"
-    ],
-    "properties": [
-      "rdf:type",
-      "mu:uuid",
-      "dct:source",
-      "skos:prefLabel",
-      {
-        "s-prefix": "schema:contactPoint",
-        "properties": [
-          "foaf:firstName",
-          "foaf:familyName",
-          "schema:telephone",
-          "schema:email"
-        ]
-      }
-    ]
-  }
-}
+#### How to create a SemanticFormDirectory
+
+Defining a [SemanticFormDirectory](#semanticforms-the-semanticformdirectory) has been kept rather simple. You achieve this by creating a directory within the [`SEMANTIC_FORM_CONFIGURATION_ROOT`](#environment-variables) that contains a sub-directory called `/versions`:
+
+```shell
+# we have only one form
+$ mkdir versions
 ```
-> **NOTE**: properties can be nested indefinitely.
-    
-### FormData files: turtle-files
+```shell
+# we want to name our form(s)
+$ mkdir -p /my-form/versions
+```
+```shell
+# we want to nest our form(s)
+$ mkdir -p phase-1/my-form/versions
+```
 
-Within this folder you also drop the `.ttl` files to be used to: construct, process and visualize the semantic-forms.
+Simply put, any recursively nested folder within the [`SEMANTIC_FORM_CONFIGURATION_ROOT`](#environment-variables) containing a `/versions` folder, is picked-up as a SemanticFormDirectory.
 
-#### Example
+> **Developer note:**  
+> In theory, you could create any desired directory structure within the [`SEMANTIC_FORM_CONFIGURATION_ROOT`](#environment-variables).  
+> **But, this has never been extensively tested. So explore this at your own discretion**.
+
+#### What is the `/versions` sub-directory?
+
+Directory where your different versions of [SemanticFormSpecification](#semanticforms-the-semanticformspecification) will live.
+
+> **Note:** This sub-directory is **required** for the parent directory to be recognized as a [SemanticFormDirectory](#semanticforms-the-semanticformdirectory) and cannot hold another name.
+
+### SemanticForm(s): The SemanticFormSpecification
+
+Is a timestamped directory, within the [`/versions`](#what-is-the-versions-sub-directory) directory containing a pair of two files:
+- [The turtle form-specification](#the-turtle-form-specification)
+- [The json meta-data for the turtle form-specification](#the-json-meta-data-for-the-turtle-form-specification)
+
+All [SemanticFormSpecification](#semanticforms-the-semanticformspecification) directories are **required** to have a **timestamp** in the [format](https://momentjs.com/docs/#/parsing/string-format/) `YYYYMMDDhhmmss` followed by a dash(-) and a title/description. This timestamp will be inferred as the creation date of its configuration files.
+
+#### What about migrations, should the files be added manually to the store?
+
+No, migrations are not required. The files are inserted into the store by the service itself. We follow the same [model](https://github.com/mu-semtech/file-service#model) as defined by the [file-service](https://github.com/mu-semtech/file-service).
+
+#### UUID generation
+
+To ensure consistent UUID generation on different environments, we make use of [UUIDv5](https://datatracker.ietf.org/doc/html/rfc4122#section-4.3) with a fixed namespace.
+
+> **Developer note**:  
+> For the more tech-savvy, the following namespace & name are used when generating the UUID's:
+>   - physical UUID: `uuidv5("77219b1e-e23d-4828-847f-55e2d7fac687", [physical-uri])`
+>   - virtual UUID:  `uuidv5("77219b1e-e23d-4828-847f-55e2d7fac687", [physical-uuid])`
+
+#### The turtle form-specification
 
 ```
 @prefix form: <http://lblod.data.gift/vocabularies/forms/> .
@@ -157,25 +187,135 @@ form:6b70a6f0-cce2-4afe-81f5-5911f45b0b27 a form:Form ;
 
 ```
 
+#### The json meta-data for the turtle form-specification
+
+```json
+{
+  "meta": {
+    "schemes": [
+    ]
+  },
+  "resource": {
+    "prefixes": [
+      "PREFIX mu: <http://mu.semte.ch/vocabularies/core/>",
+      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
+      "PREFIX dct: <http://purl.org/dc/terms/>",
+      "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>",
+      "PREFIX schema: <http://schema.org/>",
+      "PREFIX foaf: <http://xmlns.com/foaf/0.1/>"
+    ],
+    "properties": [
+      "rdf:type",
+      "mu:uuid",
+      "dct:source",
+      "skos:prefLabel",
+      {
+        "s-prefix": "schema:contactPoint",
+        "properties": [
+          "foaf:firstName",
+          "foaf:familyName",
+          "schema:telephone",
+          "schema:email"
+        ]
+      }
+    ]
+  }
+}
+```
+> **Developer note**:
+> - `meta.schemes` is optional.
+> - properties can be nested indefinitely.
+
+### [experimental] SemanticForm(s): Tailored data
+
+Sometimes SemanticForms need to be enhanced with user specific business logic, for this the concept of tailored data was introduced. **Take notice that this is still very experimental. Use at your own discretion.**
+
+#### How to create tailored meta/source-data extractors
+
+Tailored data is SemanticForm specific, so you'll have to navigate to the matching [SemanticFormDirectory](#semanticforms-the-semanticformdirectory). Next to the `/versions` directory, you'll create the following directories:
+
+```shell
+# meta data extractors
+$ mkdir -p tailored/meta
+```
+```shell
+# source data extractors
+$ mkdir -p tailored/source
+```
+Within these directories you'll define an `index.js` that exports an array of extractors. These will be called on enhancement of a new SemanticForm.
+
+> NOTE: these extractors run in the order of definition
+
+For a starter example, take a look in root of this repository under `./examples`.
+
+### [deprecated] ~~Mapper~~
+
+At inception, to be submitted SemanticForms would be mapped to a pre-defined (clean) model.
+
+This mapper provided the functionality to create new resources, map/copy fields and create relations to map the SemanticForm fields to the correct pre-defined model.
+
+This functionality was abandoned after the responsibility was moved to other services in an effort to simplify the process.  
+See [commit](https://github.com/lblod/subsidy-applications-management-service/commit/945af4b7b7e388f139d51ffe9494edb1500e7bb9).
+
+## Generates
+
+### SemanticForm(s): MetaData
+
+Extra data that is needed by the client to correctly render the form. **Initially, at startup, the service does not generate meta-data.** It only starts once a client has requested a SemanticForm that needs meta-data.
+
+#### Where and how is it stored?
+
+All the meta-data is stored in turtle files. These files can be found in the [`META_DATA_ROOT`](#environment-variables) under the same folder structure defined by its paired SemanticFormDirectory.
+
+#### Is the meta-data up-to-date?
+
+To ensure that the meta-data is up-to-date, when a user requests a new SemanticForm to be build, a process is started to generate the required meta-data.
+
+This process can be very expensive and time-consuming. Therefore, a background task is triggered to check at predefined intervals if the meta-data has been updated. If the meta-data is out-of-date, a new updated meta-data file is generated.
+
+To prevent dangling background processes, if this background task was not triggered by a client within the specified [`META_DATA_STALE_CRON_STOP`](#environment-variables) days, it is turned off.
+
+#### Wouldn't it be too eager during a migration that targets the meta-data sources?
+
+To prevent this from happening, if a change to the meta-data is detected, a backoff was implemented.
+
+This means that if a change was detected, it will wait and retry. If it changed again, we assume to be in an unstable state. So we, backoff and retry again later. This process will continue until:
+1. the meta-data source have stabilized
+2. maximum backoff wait has been reached, meaning we'll retry at a later rotation
+
+<details>
+<summary>Backoff environment variables</summary>
+
+These can be added in within the docker declaration.
+
+| Name                                        | Description                                  | Default         |
+|---------------------------------------------|----------------------------------------------|-----------------|
+| `META_DATA_EXTRACTION_BACKOFF_INITIAL_WAIT` | The initial wait time                        | 5000            |
+| `META_DATA_EXTRACTION_BACKOFF_RATE`         | backoff rate                                 | 0.3             |
+| `META_DATA_EXTRACTION_BACKOFF_MAX_WAIT`     | maximum wait time                            | 600000 "10 min" |
+</details>
+
 ## API
 
-### Get the current active form directory.
+### Get the configuration and latest meta-data to be used.
 
-> **GET** `/active-form-directory`
+> **GET** `/sources/latest?uri`
 
 ```
 HTTP/1.1 
 200 OK
 X-Powered-By: Express
 content-type: application/json; charset=utf-8
-Date: Tue, 17 Nov 2020 08:47:01 GMT
 
 {
-  type: "form-version-directory",
-  id: "1",
-  attributes: {
-    uri: "share://versions/YYYYMMDDhhmmss-active-form-directory",
-  }
+  "configuration": {
+    "specification": ""
+    "tailored": {
+      "meta": ""
+      "source": ""
+    }
+  },
+  "meta": "",
 }
 ```
 
@@ -190,7 +330,6 @@ HTTP/1.1
 200 OK
 X-Powered-By: Express
 content-type: application/json; charset=utf-8
-Date: Tue, 17 Nov 2020 08:47:01 GMT
 
 {
   "form": "",
@@ -226,7 +365,6 @@ Accept: application/json
 HTTP/1.1 
 204 No Content
 x-powered-by: Express
-Date: Tue, 17 Nov 2020 08:47:01 GMT
 ```
 
 ### Submit a semantic-form
@@ -238,14 +376,24 @@ Date: Tue, 17 Nov 2020 08:47:01 GMT
 HTTP/1.1 
 204 No Content
 x-powered-by: Express
-Date: Tue, 17 Nov 2020 08:47:01 GMT
+```
+
+### Sync all meta-data
+
+> **GET** `/meta/sync`
+
+> NOTE: heavy request as this triggers an update for all configured SemanticFormSpecifications
+
+#### Response
+```
+HTTP/1.1 
+204 No Content
+x-powered-by: Express
 ```
 
 ## Development
 
-For a more detailed look in how to develop a microservices based on
-the [mu-javascript-template](https://github.com/mu-semtech/mu-javascript-template), we would recommend
-reading "[Developing with the template](https://github.com/mu-semtech/mu-javascript-template#developing-with-the-template)"
+For a more detailed look in how to develop a microservices based on the [mu-javascript-template](https://github.com/mu-semtech/mu-javascript-template), we would recommend reading "[Developing with the template](https://github.com/mu-semtech/mu-javascript-template#developing-with-the-template)".
 
 ### Developing in the `mu.semte.ch` stack
 

--- a/lib/entities/semantic-form-configuration.js
+++ b/lib/entities/semantic-form-configuration.js
@@ -30,8 +30,8 @@ export class SemanticFormConfiguration {
     this.root = root;
     this.sources = sources;
 
-    // NOTE: triggers validation
-    this.specification;
+    // NOTE: trigger validation
+    this.specification.validate();
   }
 
   /**

--- a/lib/entities/semantic-form-specification.js
+++ b/lib/entities/semantic-form-specification.js
@@ -1,4 +1,4 @@
-import { FORM, Graph, parse, RDFNode } from '../util/rdflib';
+import {FORM, Graph, parse, RDFNode} from '../util/rdflib';
 import uniq from 'lodash.uniq';
 
 export const SPEC_FILE_MATCHER = 'form.ttl';
@@ -9,24 +9,22 @@ const GRAPH = 'http://form-spec/1701';
 export class SemanticFormSpecification {
 
   constructor(sources) {
-
     this.sources = sources;
 
-    const buffer = [];
-    buffer.push('[ERROR] Missing form-specification files:');
-    if (!this.turtle) {
-      buffer.push(`\t\t- ${SPEC_FILE_MATCHER}`);
-    }
-    if (!this.json) {
-      buffer.push(`\t\t- ${CONFIG_FILE_MATCHER}`);
-    }
-    if (buffer.length > 1) {
-      throw buffer.join('\n');
-    }
+    this._store = new Graph();
+    this.parsed = false;
+  }
 
-    /* Initialize store with spec. TTL */
-    this.store = new Graph();
-    parse(this.turtle.content, this.store, {graph: GRAPH});
+  get store() {
+    if (!this.parsed) {
+      /* Initialize store with spec. TTL */
+      try {
+        parse(this.turtle.content, this._store, {graph: GRAPH});
+      } catch (e) {
+        // NOTE: if it fails, it fails.
+      }
+    }
+    return this._store
   }
 
   get content() {
@@ -38,23 +36,40 @@ export class SemanticFormSpecification {
   }
 
   get json() {
-    return this.sources.find(file => file.filename.includes(CONFIG_FILE_MATCHER));
+    return this.sources.find(
+        file => file.filename.includes(CONFIG_FILE_MATCHER));
   }
 
   get schemes() {
     /* schemes in spec */
-    let schemes = this.store.match(undefined, FORM('options'), undefined, new RDFNode(GRAPH)).
+    let schemes = this.store.match(undefined, FORM('options'), undefined,
+        new RDFNode(GRAPH)).
         map(op => JSON.parse(op.object.value)).
         filter(op => !!op.conceptScheme).
         map(op => op.conceptScheme);
     /* enhanced with json config */
-    if (this.json.content.meta && this.json.content.meta['schemes'] && this.json.content.meta['schemes'].length > 0)
+    if (this.json.content.meta && this.json.content.meta['schemes'] &&
+        this.json.content.meta['schemes'].length > 0)
       schemes = schemes.concat(this.json.content.meta['schemes']);
     return uniq(schemes);
   }
 
   get definition() {
     return enrichUserDefinition(this.json.content['source']);
+  }
+
+  validate() {
+    const buffer = [];
+    buffer.push('[ERROR] Missing form-specification files:');
+    if (!this.turtle) {
+      buffer.push(`\t\t- ${SPEC_FILE_MATCHER}`);
+    }
+    if (!this.json) {
+      buffer.push(`\t\t- ${CONFIG_FILE_MATCHER}`);
+    }
+    if (buffer.length > 1) {
+      throw buffer.join('\n');
+    }
   }
 
   toJSON() {

--- a/lib/entities/semantic-form.js
+++ b/lib/entities/semantic-form.js
@@ -1,6 +1,7 @@
-import { sparqlEscape } from 'mu';
-import { SemanticFile } from './semantic-file';
-import { SEMANTIC_FORM_TYPE } from '../../env';
+import {sparqlEscape} from 'mu';
+import {SemanticFile} from './semantic-file';
+import {SEMANTIC_FORM_TYPE} from '../../env';
+import {SemanticFormBundle} from './semantic-form-bundle';
 
 export const SEMANTIC_FORM_STATUS = {
   SENT: 'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c',
@@ -13,7 +14,14 @@ export const SEMANTIC_FORM_STATUS = {
  */
 export class SemanticForm {
 
-  constructor({graph, uri, uuid, status, sources = [], type = SEMANTIC_FORM_TYPE} = {}) {
+  constructor({
+    graph,
+    uri,
+    uuid,
+    status,
+    sources = [],
+    type = SEMANTIC_FORM_TYPE,
+  } = {}) {
     this.type = type;
     this.graph = graph;
     this.uri = uri;
@@ -39,6 +47,10 @@ export class SemanticForm {
     return this._sources;
   }
 
+  get bundle() {
+    return new SemanticFormBundle(this._sources);
+  }
+
   /**
    * Returns the POJO class as a valid n-triples.
    *
@@ -60,7 +72,8 @@ export class SemanticForm {
 
     buffer.push(`<${this.uri}> a <${this.type}> .`);
     if (this.uuid)
-      buffer.push(`<${this.uri}> mu:uuid ${sparqlEscape(this.uuid, 'string')} .`);
+      buffer.push(
+          `<${this.uri}> mu:uuid ${sparqlEscape(this.uuid, 'string')} .`);
     if (this.status)
       buffer.push(`<${this.uri}> adms:status <${this.status}> .`);
     this.sources.forEach(source => {

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -73,6 +73,93 @@ export class SemanticFormManagement {
   }
 
   /**
+   * Enriches a semantic-form with the latest, needed sources
+   * - specification TLL
+   * - specification JSON
+   * - meta
+   * - tailored
+   *
+   * @param form
+   * @returns {Promise<void>}
+   */
+  async enrichSemanticForm(form) {
+    const uuid = form.uuid;
+
+    let sources = {};
+    try {
+      sources = await this.configuration.sources.getLatest(form.sources[0].uri);
+    } catch (error) {
+      throw {
+        status: 404,
+        resource: {
+          uuid
+        },
+        message: `Could not retrieve/find form configuration for semantic-form """${uuid}"""`
+      };
+    }
+
+    let {configuration, meta} = sources;
+
+    form.sources = [
+      configuration.specification.turtle,
+      configuration.specification.json
+    ];
+    if (meta)
+      form.sources.push(meta);
+
+    /**
+     * NOTE: generate and save tailored TTL if is has been configured.
+     */
+    if (configuration.tailored.meta) {
+      const extractors = configuration.tailored.meta.content;
+      const {additions} = await new TailoredMetaDataExtractor(form).execute(extractors);
+
+      /**
+       * NOTE: if additions were found, we create a unique file that contains this meta-data
+       */
+      if (additions) {
+        const filename = `${TAILORED_META_DATA_ROOT}${uuidv4()}${TAILORED_META_FILE_MATCHER.additions}`;
+        const file = new SemanticFile({filename});
+        SemanticFile.write(file, additions);
+        form.sources.push(file); // NOTE: linking it to the semantic-form
+
+        try {
+          await this.mutator.insert(file.toNT(), form.graph);
+        } catch (e) {
+          console.warn(`Failed saving extracted tailored meta-data for ${uuid}`);
+          console.log(e);
+          // NOTE: try to clean-up dangling file
+          SemanticFile.unlink(file);
+        }
+      }
+    }
+
+    /**
+     * NOTE: generate and save tailored source TTL if is has been configured.
+     */
+    if (configuration && configuration.tailored.source) {
+      const extractors = configuration.tailored.source.content;
+      const {additions} = await new TailoredMetaDataExtractor(form).execute(extractors);
+      if (additions) {
+        try {
+          await this.mutator.insert(additions, form.graph);
+        } catch (e) {
+          console.warn(`Failed saving extracted start (source) data for ${uuid}`);
+          console.log(e);
+        }
+      }
+    }
+
+    // SAVE
+    try {
+      await this.updateSemanticForm(uuid, form);
+    } catch (e) {
+      console.warn(`Failed updating sources for semantic-form with ${uuid}`);
+      console.log(e);
+    }
+  }
+
+  /**
    * Returns the {@link SemanticFormBundle} for the given UUID.
    *
    * TODO:  add some post-processing on the meta-data to enforce user-specific business logic.
@@ -85,107 +172,16 @@ export class SemanticFormManagement {
     const form = await this.getSemanticForm(uuid);
 
     /**
-     * NOTE: in the case where one source is set, we assume it to be the form.ttl (new semantic-form)
+     * NOTE: we enrich the form when we assume it to be pristine:
+     * - the status is NEW
+     * - only one source is set, we assume it to be the form.ttl (new semantic-form)
+     *
+     * TODO: make this a little more type safe / solid
      */
-    if (form.sources.length === 1) {
-      // TODO: make this a little more type safe / solid
-      let sources = {};
-      try {
-        sources = await this.configuration.sources.getLatest(form.sources[0].uri);
-      } catch (error) {
-        throw {
-          status: 404,
-          resource: {
-            uuid: form.uuid
-          },
-          message: `Could not retrieve/find form configuration for the semantic-form ${uuid}`
-        };
-      }
+    if (form.status === SEMANTIC_FORM_STATUS.NEW || form.sources.length === 1)
+      await this.enrichSemanticForm(form);
 
-      let {configuration, meta} = sources;
-
-      form.sources = [
-        configuration.specification.turtle,
-        configuration.specification.json
-      ];
-      if (meta)
-        form.sources.push(meta);
-
-      /**
-       * NOTE: generate and save tailored TTL if is has been configured.
-       */
-      if (configuration.tailored.meta) {
-        const extractors = configuration.tailored.meta.content;
-        const {additions} = await new TailoredMetaDataExtractor(form).execute(extractors);
-
-        /**
-         * NOTE: if additions were found, we create a unique file that contains this meta-data
-         */
-        if (additions) {
-          const filename = `${TAILORED_META_DATA_ROOT}${uuidv4()}${TAILORED_META_FILE_MATCHER.additions}`;
-          const file = new SemanticFile({filename});
-          SemanticFile.write(file, additions);
-          form.sources.push(file); // NOTE: linking it to the semantic-form
-
-          try {
-            await this.mutator.insert(file.toNT(), form.graph);
-          } catch (e) {
-            console.warn(`Failed saving extracted tailored meta-data ${uuid}`);
-            console.log(e);
-            // NOTE: try to clean-up dangling file
-            SemanticFile.unlink(file);
-          }
-        }
-      }
-
-      // SAVE
-      try {
-        await this.updateSemanticForm(uuid, form);
-      } catch (e) {
-        console.warn(`Failed updating sources for semantic-form with ${uuid}`);
-        console.log(e);
-      }
-    }
-
-    if (form.status === SEMANTIC_FORM_STATUS.NEW) {
-      const ttlSource = mostRecentSource(form.sources.filter(source => source.physicalURI.endsWith('form.ttl')));
-      const configuration = (await this.configuration.sources.getLatest(ttlSource.uri)).configuration;
-
-      if (configuration && configuration.tailored.source) {
-        // Clean previously extracted data
-        const removes = await new SourceDataExtractor().extract(form.uri, configuration.specification.definition);
-        if (removes) {
-          try {
-            await this.mutator.delete(removes, form.graph);
-          } catch (e) {
-            console.warn(`Failed removing extracted source data ${uuid}`);
-            console.log(e);
-          }
-        }
-
-        // Extract new data
-        const extractors = configuration.tailored.source.content;
-        const {additions} = await new TailoredMetaDataExtractor(form).execute(extractors);
-        if (additions) {
-          try {
-            await this.mutator.insert(additions, form.graph);
-          } catch (e) {
-            console.warn(`Failed saving extracted start (source) data ${uuid}`);
-            console.log(e);
-          }
-        }
-
-        // SAVE
-        try {
-          await this.updateSemanticForm(uuid, form);
-        } catch (e) {
-          console.warn(`Failed updating sources for semantic-form with ${uuid}`);
-          console.log(e);
-        }
-      }
-    }
-
-    const bundle = new SemanticFormBundle(form.sources);
+    const bundle = form.bundle;
 
     /**
      * NOTE: we expect that at this point sources (spec., meta, ...) have been set on the semantic-form
@@ -391,19 +387,4 @@ WHERE {
     };
   }
   return response.results.bindings.map(binding => binding.source.value);
-}
-
-function mostRecentSource(sources) {
-  return sources.reduce(function (previousMostRecent, currentMostRecent) {
-    const previousTimestamp = previousMostRecent ? getTimestamp(previousMostRecent.physicalURI) : 0;
-    const currentTimestamp = getTimestamp(currentMostRecent.physicalURI);
-    return (previousTimestamp > currentTimestamp) ? previousMostRecent : currentMostRecent;
-  });
-}
-
-function getTimestamp(fileAddress) {
-  const splittedPhysicalUri = fileAddress.split('/');
-  const timestampedFolder = splittedPhysicalUri[splittedPhysicalUri.length - 2];
-  const timestamp = timestampedFolder.split('-')[0];
-  return timestamp;
 }

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -162,8 +162,6 @@ export class SemanticFormManagement {
   /**
    * Returns the {@link SemanticFormBundle} for the given UUID.
    *
-   * TODO:  add some post-processing on the meta-data to enforce user-specific business logic.
-   *
    * [CONSIDERED AUTH. SAFE]
    *
    * @param uuid

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -146,17 +146,23 @@ export class SemanticFormManagement {
      * NOTE: generate and save tailored source TTL if is has been configured.
      */
     if (configuration && configuration.tailored.source) {
+
+      // NOTE: clean-up old, and possibly broken source-data
+      try {
+        const deprecated =
+            await new SourceDataExtractor().extract(
+                form.uri,
+                form.bundle.specification.definition);
+        await this.mutator.delete(deprecated, form.graph);
+      } catch (e) {
+        // it's ok if this fails.
+      }
+
       const extractors = configuration.tailored.source.content;
       const {additions} =
           await new TailoredMetaDataExtractor(form).execute(extractors);
       if (additions) {
         try {
-          // NOTE: clean-up old, and possibly broken data
-          const deprecated =
-              await new SourceDataExtractor().extract(
-                  form.uri,
-                  form.bundle.specification.definition);
-          await this.mutator.delete(deprecated, form.graph);
           await this.mutator.insert(additions, form.graph);
         } catch (e) {
           console.warn(

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -170,9 +170,9 @@ export class SemanticFormManagement {
     const form = await this.getSemanticForm(uuid);
 
     /**
-     * NOTE: we enrich the form when we assume it to be pristine:
+     * NOTE: we enrich the form when we assume it to be new or incomplete :
      * - the status is NEW
-     * - only one source is set, we assume it to be the form.ttl (new semantic-form)
+     * - only one source is set, we assume this to be the form.ttl
      *
      * TODO: make this a little more type safe / solid
      */

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -1,16 +1,20 @@
-import { sparqlEscape, uuid as uuidv4 } from 'mu';
-import { authenticatedQuery, query } from '../util/database';
-import { DEBUG_LOGS, SEMANTIC_FORM_TYPE, TAILORED_META_DATA_ROOT } from '../../env';
-import { SemanticForm, SEMANTIC_FORM_STATUS } from '../entities/semantic-form';
-import { COMMON_GRAPHS, NTriplesMutator } from './n-triples-mutator';
-import { FORM, Graph, parse, RDF, RDFNode } from '../util/rdflib';
-import { validateForm } from '@lblod/submission-form-helpers';
-import { SemanticFormBundle } from '../entities/semantic-form-bundle';
-import { SourceDataExtractor } from './source-data-extractor';
-import { TailoredMetaDataExtractor } from './tailored-meta-data-extractor';
-import { SemanticFile } from '../entities/semantic-file';
-import { mkDirIfNotExistsSync } from '../util/file';
-import { TAILORED_META_FILE_MATCHER } from '../entities/semantic-form-meta';
+import {sparqlEscape, uuid as uuidv4} from 'mu';
+import {authenticatedQuery, query} from '../util/database';
+import {
+  DEBUG_LOGS,
+  SEMANTIC_FORM_TYPE,
+  TAILORED_META_DATA_ROOT,
+} from '../../env';
+import {SemanticForm, SEMANTIC_FORM_STATUS} from '../entities/semantic-form';
+import {COMMON_GRAPHS, NTriplesMutator} from './n-triples-mutator';
+import {FORM, Graph, parse, RDF, RDFNode} from '../util/rdflib';
+import {validateForm} from '@lblod/submission-form-helpers';
+import {SemanticFormBundle} from '../entities/semantic-form-bundle';
+import {SourceDataExtractor} from './source-data-extractor';
+import {TailoredMetaDataExtractor} from './tailored-meta-data-extractor';
+import {SemanticFile} from '../entities/semantic-file';
+import {mkDirIfNotExistsSync} from '../util/file';
+import {TAILORED_META_FILE_MATCHER} from '../entities/semantic-form-meta';
 
 /**
  * Service providing all management logic/services for semantic-forms.
@@ -49,7 +53,8 @@ export class SemanticFormManagement {
          * NOTE: build in the case of the small change that multiple forms are found for the same UUID.
          *       As this has a small chance of happening a silent warning is thrown.
          */
-        console.warn(`Multiple results where found for semantic-form with UUID <${uuid}>.\n Data could be corrupted?`);
+        console.warn(
+            `Multiple results where found for semantic-form with UUID <${uuid}>.\n Data could be corrupted?`);
       }
 
       const form = forms[0];
@@ -65,9 +70,9 @@ export class SemanticFormManagement {
       throw {
         status: 400,
         resource: {
-          uuid: uuid
+          uuid: uuid,
         },
-        message: `You do not have access to OR we could not retrieve the semantic-form.`
+        message: `You do not have access to OR we could not retrieve the semantic-form.`,
       };
     }
   }
@@ -87,14 +92,15 @@ export class SemanticFormManagement {
 
     let sources = {};
     try {
-      sources = await this.configuration.sources.getLatest(form.sources[0].uri);
+      sources = await this.configuration.sources.getLatest(
+          form.bundle.specification.turtle.uri);
     } catch (error) {
       throw {
         status: 404,
         resource: {
-          uuid
+          uuid,
         },
-        message: `Could not retrieve/find form configuration for semantic-form """${uuid}"""`
+        message: `Could not retrieve/find form configuration for semantic-form """${uuid}"""`,
       };
     }
 
@@ -102,7 +108,7 @@ export class SemanticFormManagement {
 
     form.sources = [
       configuration.specification.turtle,
-      configuration.specification.json
+      configuration.specification.json,
     ];
     if (meta)
       form.sources.push(meta);
@@ -112,7 +118,8 @@ export class SemanticFormManagement {
      */
     if (configuration.tailored.meta) {
       const extractors = configuration.tailored.meta.content;
-      const {additions} = await new TailoredMetaDataExtractor(form).execute(extractors);
+      const {additions} = await new TailoredMetaDataExtractor(form).execute(
+          extractors);
 
       /**
        * NOTE: if additions were found, we create a unique file that contains this meta-data
@@ -126,7 +133,8 @@ export class SemanticFormManagement {
         try {
           await this.mutator.insert(file.toNT(), form.graph);
         } catch (e) {
-          console.warn(`Failed saving extracted tailored meta-data for ${uuid}`);
+          console.warn(
+              `Failed saving extracted tailored meta-data for ${uuid}`);
           console.log(e);
           // NOTE: try to clean-up dangling file
           SemanticFile.unlink(file);
@@ -139,12 +147,14 @@ export class SemanticFormManagement {
      */
     if (configuration && configuration.tailored.source) {
       const extractors = configuration.tailored.source.content;
-      const {additions} = await new TailoredMetaDataExtractor(form).execute(extractors);
+      const {additions} = await new TailoredMetaDataExtractor(form).execute(
+          extractors);
       if (additions) {
         try {
           await this.mutator.insert(additions, form.graph);
         } catch (e) {
-          console.warn(`Failed saving extracted start (source) data for ${uuid}`);
+          console.warn(
+              `Failed saving extracted start (source) data for ${uuid}`);
           console.log(e);
         }
       }
@@ -185,7 +195,8 @@ export class SemanticFormManagement {
      * NOTE: we expect that at this point sources (spec., meta, ...) have been set on the semantic-form
      */
     bundle.source = {
-      content: await new SourceDataExtractor().extract(form.uri, bundle.specification.definition)
+      content: await new SourceDataExtractor().extract(form.uri,
+          bundle.specification.definition),
     };
     return {form, bundle};
   }
@@ -201,7 +212,8 @@ export class SemanticFormManagement {
    */
   async deleteSemanticForm(uuid) {
     const {form, bundle} = await this.getSemanticFormBundle(uuid);
-    blockMutationsReadOnly(form, 'Could not delete the semantic-form as it has already been submitted.');
+    blockMutationsReadOnly(form,
+        'Could not delete the semantic-form as it has already been submitted.');
     await this.mutator.delete(bundle.source.content, form.graph);
     await this.mutator.delete(form.toNT(), form.graph);
   }
@@ -220,11 +232,12 @@ export class SemanticFormManagement {
    */
   async updateSemanticForm(uuid, delta) {
     const old = await this.getSemanticForm(uuid);
-    blockMutationsReadOnly(old, 'Could not update the semantic-form as it has already been submitted.');
+    blockMutationsReadOnly(old,
+        'Could not update the semantic-form as it has already been submitted.');
     if (delta instanceof SemanticForm) {
       delta = {
         removals: old.toNT(),
-        additions: delta.toNT()
+        additions: delta.toNT(),
       };
     }
     await this.mutator.update(delta, old.graph);
@@ -246,7 +259,8 @@ export class SemanticFormManagement {
    */
   async submitSemanticForm(uuid) {
     const {form, bundle} = await this.getSemanticFormBundle(uuid);
-    blockMutationsReadOnly(form, 'Could not submit the semantic-form as it has already been submitted.');
+    blockMutationsReadOnly(form,
+        'Could not submit the semantic-form as it has already been submitted.');
 
     if (isValid(form, bundle)) {
       // NOTE: model-mapping
@@ -265,9 +279,9 @@ export class SemanticFormManagement {
       throw {
         status: 422,
         resource: {
-          uuid: uuid
+          uuid: uuid,
         },
-        message: `Could not submit the semantic-form, validation failed.`
+        message: `Could not submit the semantic-form, validation failed.`,
       };
     }
   }
@@ -289,9 +303,9 @@ function blockMutationsReadOnly(form, message) {
     throw {
       status: 409,
       resource: {
-        uuid: form.uuid
+        uuid: form.uuid,
       },
-      message
+      message,
     };
   }
 }
@@ -308,11 +322,12 @@ function isValid(form, {source, specification}) {
     formGraph: 'http://form-graph',
     sourceGraph: 'http://source-graph',
     sourceNode: RDFNode(form.uri),
-    store
+    store,
   };
   parse(specification.content, store, {graph: options.formGraph});
   parse(source.content, store, {graph: options.sourceGraph});
-  const form_statements = store.any(undefined, RDF('type'), FORM('Form'), RDFNode('http://form-graph'));
+  const form_statements = store.any(undefined, RDF('type'), FORM('Form'),
+      RDFNode('http://form-graph'));
   return validateForm(form_statements, options);
 }
 
@@ -347,16 +362,16 @@ async function getSemanticFormsInStore(uuid, {sudo = false} = {}) {
     throw {
       status: 500,
       resource: {
-        uuid: uuid
+        uuid: uuid,
       },
-      message: `Something unexpected went wrong while trying to retrieve the semantic-form.`
+      message: `Something unexpected went wrong while trying to retrieve the semantic-form.`,
     };
   }
   return response.results.bindings.map(binding => new SemanticForm({
     graph: binding.graph.value,
     uri: binding.uri.value,
     uuid,
-    status: binding.status.value
+    status: binding.status.value,
   }));
 }
 
@@ -379,9 +394,9 @@ WHERE {
     throw {
       status: 500,
       resource: {
-        form: formPOJO
+        form: formPOJO,
       },
-      message: `Something unexpected went wrong while trying to retrieve the sources for form.`
+      message: `Something unexpected went wrong while trying to retrieve the sources for form.`,
     };
   }
   return response.results.bindings.map(binding => binding.source.value);

--- a/lib/services/semantic-form-management.js
+++ b/lib/services/semantic-form-management.js
@@ -147,10 +147,16 @@ export class SemanticFormManagement {
      */
     if (configuration && configuration.tailored.source) {
       const extractors = configuration.tailored.source.content;
-      const {additions} = await new TailoredMetaDataExtractor(form).execute(
-          extractors);
+      const {additions} =
+          await new TailoredMetaDataExtractor(form).execute(extractors);
       if (additions) {
         try {
+          // NOTE: clean-up old, and possibly broken data
+          const deprecated =
+              await new SourceDataExtractor().extract(
+                  form.uri,
+                  form.bundle.specification.definition);
+          await this.mutator.delete(deprecated, form.graph);
           await this.mutator.insert(additions, form.graph);
         } catch (e) {
           console.warn(
@@ -195,7 +201,8 @@ export class SemanticFormManagement {
      * NOTE: we expect that at this point sources (spec., meta, ...) have been set on the semantic-form
      */
     bundle.source = {
-      content: await new SourceDataExtractor().extract(form.uri,
+      content: await new SourceDataExtractor().extract(
+          form.uri,
           bundle.specification.definition),
     };
     return {form, bundle};


### PR DESCRIPTION
Took a closer look at the logic for enriching new/incomplete semantic-forms. Noticed that some things could be improved by changing the logic a bit, reusing existing code. 

Due to you, @claire-lovisa, introducing the tailored-source logic, I'd like it if you had a second look. Make sure everything still works as you intended.