### PR TITLE
bump template version & fix ENV value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,1 @@
 FROM semtech/mu-javascript-template:1.6.0
-
-ENV LOG_SPARQL_ALL "false"
-ENV DEBUG_AUTH_HEADERS "false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM semtech/mu-javascript-template:1.4.0
-LABEL maintainer=""
+FROM semtech/mu-javascript-template:1.6.0
 
-ENV LOG_SPARQL_ALL null
-ENV DEBUG_AUTH_HEADERS null
+ENV LOG_SPARQL_ALL "false"
+ENV DEBUG_AUTH_HEADERS "false"


### PR DESCRIPTION
There are 2 lines in the log that I dont understand as well 
```
cp: can't create directory '/usr/src/app/app/config/forms': No such file or directory
cp: can't create '/usr/src/app/app/config/mapper.js': No such file or directory
``` 
I assume that mu-template expects that the folder and files that will go in config should already exist in the microservice 
it still works as expected so dont think this should be addressed for now